### PR TITLE
add option to only preprocess certain files

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,15 +39,19 @@ Nothing required
 
 `hardhat-preprocessor` also add a new task: `preprocess`
 
-`hardhat preprocess [--dest <destination folder> --files <specific files to preprocess>]`
+`hardhat preprocess [--dest <destination folder> --files <specific files or glob pattern to preprocess>]`
 
 * This task will write the modification to disk. 
 * By default it overwrite the sources. 
 * If the `dest` option is set, it will write in that folder instead (and keep sources intact). 
-* If the `files` option is set, it will only pre-process those files (instead of all files). The path to the files is relative to the source path. 
+* If the `files` option is set, it will only pre-process those files or matching glob (instead of all files). The path to the files is relative to the source path. 
 Eg:
 ```
-npx hardhat preprocess --files '["Greeter.sol"]'
+npx hardhat preprocess --files Greeter.sol 
+```
+OR
+```
+npx hardhat preprocess --files */*.sol
 ```
 
 ## Environment extensions

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ import 'hardhat-preprocessor';
 Nothing required
 
 ## Tasks
+`hardhat compile` will read config from `hardhat.config.ts` and then preprocess in-memory (ie changes will never hit the file system and you won't need to commit the changes).
 
 `hardhat-preprocessor` also add a new task: `preprocess`
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _This plugin allows to pre-process contract source code before compilation_
 
 ## What
 
-This plugin allow you to specify a function that is executed on every line of all contracts so that you can pre-process the code.
+This plugin allow you to specify a function that is executed on every line of all contracts (or specified contracts) so that you can pre-process the code.
 
 A typical example (included) is to remove console.log for production ready contracts.
 
@@ -39,9 +39,16 @@ Nothing required
 
 `hardhat-preprocessor` also add a new task: `preprocess`
 
-`hardhat preprocess [--dest <destination folder>]`
+`hardhat preprocess [--dest <destination folder> --files <specific files to preprocess>]`
 
-This task will write the modification to disk. By default it overwrite the sources. if the `dest` option is set, it will write in that folder instead (and keep sources intact).
+* This task will write the modification to disk. 
+* By default it overwrite the sources. 
+* If the `dest` option is set, it will write in that folder instead (and keep sources intact). 
+* If the `files` option is set, it will only pre-process those files (instead of all files). The path to the files is relative to the source path. 
+Eg:
+```
+npx hardhat preprocess --files '["Greeter.sol"]'
+```
 
 ## Environment extensions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-preprocessor",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Hardhat plugin that can preprocess contracts without writing to filesystem",
   "repository": "github:wighawag/hardhat-preprocessor",
   "author": "Ronan Sandford",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.7",
     "@types/fs-extra": "^5.0.4",
+    "@types/glob": "^7.2.0",
     "@types/mocha": "^5.2.5",
     "@types/node": "^8.10.38",
     "@typescript-eslint/eslint-plugin": "^3.9.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,13 +77,23 @@ function transform(linePreProcessor: LinePreprocessor, file: {absolutePath: stri
 
 task(TASK_PREPROCESS)
   .addOptionalParam('dest', 'destination folder (default to current sources)', undefined, types.string)
+  .addOptionalParam('files', 'specific files to preprocess - path relative to current sources', [], types.json)
   .setAction(async (args, hre) => {
     const linePreProcessor = await getLinePreprocessor(hre);
 
     const sources = hre.config.paths.sources;
     const destination = args.dest || sources;
+    const specificFiles = args.files;
+
     if (linePreProcessor || destination != sources) {
-      const files = await getFiles(sources);
+      let files: string[];
+      // if no specific set of files mentioned then get all files:
+      if (specificFiles.length > 0) {
+        files = specificFiles.map((file: string) => path.resolve(sources, file));
+      } else {
+        files = await getFiles(sources);
+      }
+
       if (files.length > 0) {
         await fs.ensureDir(destination);
 

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -8,6 +8,7 @@ declare module 'hardhat/types/config' {
   type LinePreprocessorConfig = {
     transform: LinePreprocessor;
     settings?: unknown;
+    files?: string;
   };
 
   interface HardhatUserConfig {

--- a/test/fixture-projects/hardhat-project-3/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-project-3/hardhat.config.ts
@@ -22,7 +22,7 @@ const config: HardhatUserConfig = {
   },
   preprocess: {
     // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-    eachLine: () => ({transform: (line) => line.replace('asdf', './Lib.sol')}),
+    eachLine: () => ({transform: (line) => line.replace('asdf', 'Lib')}),
   },
 };
 

--- a/test/fixture-projects/hardhat-project-3/src/Lib.sol
+++ b/test/fixture-projects/hardhat-project-3/src/Lib.sol
@@ -4,6 +4,7 @@ pragma solidity 0.7.3;
 import "hardhat/console.sol";
 
 contract Lib {
+    string private name = "asdf";
     function say(string calldata message) external view {
         console.log(message);
     }

--- a/test/fixture-projects/hardhat-project-3/src/Test.sol
+++ b/test/fixture-projects/hardhat-project-3/src/Test.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.7.3;
 
-import "asdf";
+import "./asdf.sol";
 
 contract Test {}

--- a/test/fixture-projects/hardhat-project-3/src/nested_folder/Test2.sol
+++ b/test/fixture-projects/hardhat-project-3/src/nested_folder/Test2.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.3;
+
+import "../asdf.sol";
+
+contract Test2 {}

--- a/test/fixture-projects/hardhat-project-4/.gitignore
+++ b/test/fixture-projects/hardhat-project-4/.gitignore
@@ -1,0 +1,3 @@
+cache/
+artifacts/
+dest/

--- a/test/fixture-projects/hardhat-project-4/hardhat.config.ts
+++ b/test/fixture-projects/hardhat-project-4/hardhat.config.ts
@@ -1,0 +1,32 @@
+// We load the plugin here.
+import '../../../src/index';
+import {HardhatUserConfig} from 'hardhat/types';
+
+const config: HardhatUserConfig = {
+  solidity: {
+    version: '0.7.3',
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 2000,
+      },
+    },
+  },
+  networks: {
+    rinkeby: {
+      url: 'http://localhost:8545',
+    },
+  },
+  paths: {
+    sources: 'src',
+  },
+  preprocess: {
+    // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+    eachLine: () => ({
+      transform: (line) => line.replace('asdf', 'Lib'),
+      files: 'Test.sol', // can also be a glob relative to the source. eg `*.sol`
+    }),
+  },
+};
+
+export default config;

--- a/test/fixture-projects/hardhat-project-4/src/Lib.sol
+++ b/test/fixture-projects/hardhat-project-4/src/Lib.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.3;
+
+import "hardhat/console.sol";
+
+contract Lib {
+    string private name = "asdf";
+    function say(string calldata message) external view {
+        console.log(message);
+    }
+}

--- a/test/fixture-projects/hardhat-project-4/src/Test.sol
+++ b/test/fixture-projects/hardhat-project-4/src/Test.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.7.3;
+
+import "./asdf.sol";
+
+contract Test {}

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -24,6 +24,7 @@ export function useEnvironment(
     if (clearCache) {
       fs.emptyDirSync('cache');
     }
+    fs.emptyDirSync('dest');
     process.env.HARDHAT_NETWORK = networkName;
 
     this.env = require('hardhat');

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -99,9 +99,9 @@ describe('Test virtual imports and name change', function () {
   });
 });
 
-describe('Preprocess specific files only', function () {
+describe('Preprocess specific files only in disk using preprocess task', function () {
   useEnvironment('hardhat-project-3', {networkName: 'hardhat', clearCache: true});
-  it('It should preprocess only specific file on hardhat', async function () {
+  it('It should preprocess only specific file', async function () {
     await this.env.run('preprocess', {dest: dest, files: "Test.sol"});
     // Test.sol should be preprocessed but not Lib.sol
     const newTestContract = fs.readFileSync(`${dest}/Test.sol`).toString();
@@ -130,4 +130,19 @@ describe('Preprocess specific files only', function () {
     // Only 2 file preprocessed
     expect(fs.readdirSync(dest)).to.have.lengthOf(2);
   })
+})
+
+describe.only('Preprocess specific files in memory only using compile task', function () {
+  useEnvironment('hardhat-project-4', {networkName: 'hardhat', clearCache: true});
+
+  it('It should preprocess only specific file on hardhat', async function () {
+    await this.env.run('compile');
+    // According to the project's hardhat config, only Test.sol should be preprocessed.
+    // Note - with compile preproessing is done in memory not on disk.
+    const newTestContract = getSource(this.env, 'src/Test.sol', 'Test');
+    expect(newTestContract).to.not.equal(fs.readFileSync('src/Test.sol').toString());
+
+    const newLibContract = getSource(this.env, 'src/Lib.sol', 'Lib');
+    expect(newLibContract).to.equal(fs.readFileSync('src/Lib.sol').toString());
+  });
 })

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -4,6 +4,8 @@ import fs from 'fs-extra';
 import path from 'path';
 import {HardhatRuntimeEnvironment} from 'hardhat/types';
 
+const dest = 'dest';
+
 function getSolcInput(env: HardhatRuntimeEnvironment, filepath: string, contractName: string) {
   const debugPath = path.join(env.config.paths.artifacts, filepath, contractName + '.dbg.json');
   const debugInfo = JSON.parse(fs.readFileSync(debugPath).toString());
@@ -53,7 +55,6 @@ describe('Hardhat compile task on rinkeby', function () {
 describe('Hardhat preprocess task on rinkeby', function () {
   useEnvironment('hardhat-project', {networkName: 'rinkeby'});
   it('It should preprocess Test.sol on rinkeby', async function () {
-    const dest = 'dest';
     await this.env.run('preprocess', {dest});
     const source = fs.readFileSync(`${dest}/Test.sol`).toString();
     expect(source).to.not.equal(fs.readFileSync('src/Test.sol').toString());
@@ -63,7 +64,6 @@ describe('Hardhat preprocess task on rinkeby', function () {
 describe('Hardhat preprocess task on hardhat', function () {
   useEnvironment('hardhat-project', {networkName: 'hardhat'});
   it('It should preprocess Test.sol on hardhat', async function () {
-    const dest = 'dest';
     await this.env.run('preprocess', {dest});
     const source = fs.readFileSync(`${dest}/Test.sol`).toString();
     expect(source).to.equal(fs.readFileSync('src/Test.sol').toString());
@@ -88,10 +88,9 @@ describe('Hardhat compile task with comments', function () {
 });
 
 describe('Test virtual imports and name change', function () {
-  useEnvironment('hardhat-project-3', {networkName: 'hardhat'});
+  useEnvironment('hardhat-project-3', {networkName: 'hardhat', clearCache: true});
 
   it('It should preprocess Test and Lib.sol', async function () {
-    fs.emptyDirSync('cache');
     await this.env.run('compile');
     const newTestContract = getSource(this.env, 'src/Test.sol', 'Test');
     expect(newTestContract).to.not.equal(fs.readFileSync('src/Test.sol').toString());
@@ -100,16 +99,35 @@ describe('Test virtual imports and name change', function () {
   });
 });
 
-describe.only('Preprocess specific files only', function () {
-  useEnvironment('hardhat-project-3', {networkName: 'hardhat'});
+describe('Preprocess specific files only', function () {
+  useEnvironment('hardhat-project-3', {networkName: 'hardhat', clearCache: true});
   it('It should preprocess only specific file on hardhat', async function () {
-    fs.emptyDirSync('cache');
-    const dest = 'dest';
-    await this.env.run('preprocess', {dest: dest, files: ["Test.sol"]});
+    await this.env.run('preprocess', {dest: dest, files: "Test.sol"});
     // Test.sol should be preprocessed but not Lib.sol
     const newTestContract = fs.readFileSync(`${dest}/Test.sol`).toString();
     expect(newTestContract).to.not.equal(fs.readFileSync('src/Test.sol').toString());
-    // Lib didn't change so it shouldn't even be in dest folder:
-    expect(fs.existsSync(`${dest}/Lib.sol`)).to.be.false;
+    // Only 1 file preprocessed, so number of files in dest should be 1
+    expect(fs.readdirSync(dest)).to.have.lengthOf(1);
   });
+
+  it("test glob - only for nested folder", async function () {
+    await this.env.run('preprocess', {dest: dest, files: '*/*.sol'});
+    // Only Test2.sol should be preprocessed
+    const newTest2Contract = fs.readFileSync(`${dest}/nested_folder/Test2.sol`).toString();
+    expect(newTest2Contract).to.not.equal(fs.readFileSync('src/nested_folder/Test2.sol').toString());
+    // Only 1 file preprocessed, so number of files in dest should be 1
+    expect(fs.readdirSync(dest)).to.have.lengthOf(1);
+  })
+
+  it("test glob - only for parent folder", async function () {
+    await this.env.run('compile');
+    await this.env.run('preprocess', {dest: dest, files: '*.sol'});
+    // Only Test and Lib.sol should be preprocessed
+    const newTestContract = getSource(this.env, 'src/Test.sol', 'Test');
+    expect(newTestContract).to.not.equal(fs.readFileSync('src/Test.sol').toString());
+    const newLibContract = getSource(this.env, 'src/Lib.sol', 'Lib');
+    expect(newLibContract).to.not.equal(fs.readFileSync('src/Lib.sol').toString());
+    // Only 2 file preprocessed
+    expect(fs.readdirSync(dest)).to.have.lengthOf(2);
+  })
 })

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -58,6 +58,13 @@ describe('Hardhat preprocess task on rinkeby', function () {
     const source = fs.readFileSync(`${dest}/Test.sol`).toString();
     expect(source).to.not.equal(fs.readFileSync('src/Test.sol').toString());
   });
+
+  it('It should preprocess only specific file on rinkeby', async function () {
+    const dest = 'dest';
+    await this.env.run('preprocess', {dest: dest, files: ["Test.sol"]});
+    const source = fs.readFileSync(`${dest}/Test.sol`).toString();
+    expect(source).to.not.equal(fs.readFileSync('src/Test.sol').toString());
+  });
 });
 
 describe('Hardhat preprocess task on hardhat', function () {
@@ -65,6 +72,13 @@ describe('Hardhat preprocess task on hardhat', function () {
   it('It should preprocess Test.sol on hardhat', async function () {
     const dest = 'dest';
     await this.env.run('preprocess', {dest});
+    const source = fs.readFileSync(`${dest}/Test.sol`).toString();
+    expect(source).to.equal(fs.readFileSync('src/Test.sol').toString());
+  });
+
+  it('It should preprocess only specific file on hardhat', async function () {
+    const dest = 'dest';
+    await this.env.run('preprocess', {dest: dest, files: ["Test.sol"]});
     const source = fs.readFileSync(`${dest}/Test.sol`).toString();
     expect(source).to.equal(fs.readFileSync('src/Test.sol').toString());
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -162,6 +162,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/glob@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
+  integrity sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
+
 "@types/json-schema@^7.0.3":
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
@@ -171,6 +179,11 @@
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.0.tgz#57f228f2b80c046b4a1bd5cac031f81f207f4f03"
   integrity sha512-RaE0B+14ToE4l6UqdarKPnXwVDuigfFv+5j9Dze/Nqr23yyuqdNvzcZi3xB+3Agvi5R4EOgAksfv3lXX4vBt9w==
+
+"@types/minimatch@*":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
+  integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
 "@types/mocha@^5.2.5":
   version "5.2.7"


### PR DESCRIPTION
Hi! I LOVE what you have built. I use it to replace certain variables at compile time (like solpp)

My team has 30+ contracts and we only need this for 1-2 files. I suspect this might be the case for several other teams! With this feature, the time to preprocess is massively reduced

Hope you accept it!